### PR TITLE
Update to use requirements.txt and some README cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains the source files for the documentation portion of the R
 This is easy:
 
 ``` bash
-pip install mkdocs mkdocs-material pygments pymdown-extensions mike
+pip install -r requirements.txt
 ```
 
 (You don't have use to the global pip if you have python environments working, but for beginners, this is the simplest way to do it.)
@@ -38,7 +38,6 @@ $$ E = mc^2 $$
 ```
 which renders as
 $$ E = mc^2 $$
-erver by 
 
 ## Publishing changes onto the docs.rosflight.org website
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+mkdocs
+mkdocs-material
+pygments
+pymdown-extensions
+mike
+


### PR DESCRIPTION
A suggestion to list pip dependencies in the `requirements.txt` file, since that's pretty standard and makes it more likely that the requirements will be kept up to date if the maintainers are using virtual environments.

Also cleans up what looks like a typo in README.